### PR TITLE
Using full reference from the gmaps for mapType

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ var data = [{
 	    <td> 
 	    <code>
 		{<br/>
-			mapTypeId: 'ROADMAP',<br/>
+			mapTypeId: google.maps.MapTypeId.ROADMAP, //or roadmap<br/>
 			zoom: 1<br/>
 		}
 		</code>


### PR DESCRIPTION
Using the full reference from google.maps object seems reliable. Apparently "ROADMAP" doesn't work, but "roadmap" does. It might be a good idea to use the map type by directly referencing to google maps
