### PR TITLE
DOM element and jQuery object support for map_div and controls_div

### DIFF
--- a/src/maplace.js
+++ b/src/maplace.js
@@ -162,8 +162,8 @@
 
 			//default options
 			this.o = {
-				map_div: '#gmap',
-				controls_div: '#controls',
+				map_div: undefined,
+				controls_div: undefined,
 				generate_controls: true,
 				controls_type: 'dropdown',
 				controls_cssclass: '',
@@ -791,6 +791,12 @@
 			}
 
 			//store dom references
+			if (typeof(this.o.map_div) === 'undefined') {
+				this.o.map_div = '#gmap';
+			}
+			if (typeof(this.o.controls_div) === 'undefined') {
+				this.o.controls_div = '#controls';
+			}
 			this.map_div = $(this.o.map_div);
 			this.controls_wrapper = $(this.o.controls_div);
 		};


### PR DESCRIPTION
Defaults for map_div and controls_div still reverts to string '#gmap'and '#controls' respectively but is not viewable in the defaults object. It's set at "store dom references" section at line 793. Feels hacky but best I could think up right now.