### PR TITLE
Adding simple MarkerClusterer functionality

### DIFF
--- a/src/maplace-0.1.3.js
+++ b/src/maplace-0.1.3.js
@@ -143,6 +143,7 @@
             this.circles = [];
             this.oMap = false;
             this.view_all_key = 'all';
+            this.view_clustered = true;
 
             this.infowindow = null;
             this.ln = 0;
@@ -952,6 +953,14 @@
                     this.current_control.activateCurrent.apply(this, [index]);
                 }
                 this.oMap.fitBounds(this.oBounds);
+                
+                //check if MarkerClusterer function exist and check is clustered view is enabled
+                //mandatory lib: http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer.js
+                if (this.view_clustered && (typeof MarkerClusterer == 'function')) {
+                    var mcOptions = {gridSize: 50, maxZoom: 15};
+                    var markerCluster = new MarkerClusterer(this.oMap, this.markers, mcOptions);
+                }
+                
                 this.CloseInfoWindow();
                 this.o.afterViewAll();
 


### PR DESCRIPTION
Now you can enable simple marker clustering functionality.

Mandatory lib:
http://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer.js
